### PR TITLE
warp spam and move ore check

### DIFF
--- a/Branches/Stable/Behaviors/obj_Hauler.iss
+++ b/Branches/Stable/Behaviors/obj_Hauler.iss
@@ -1269,6 +1269,12 @@ objectdef obj_Hauler
 	;	*	Are our miners ice mining
 	member:bool HaulerFull()
 	{
+		if ${MyShip.HasOreHold} && ${Ship.OreHoldFull}
+		{
+			UI:UpdateConsole["Ore Hold Full. Dropping off cargo."]
+			return TRUE
+		}
+		
 		if ${Config.Miner.IceMining}
 		{
 			if ${Ship.CargoFreeSpace} < 1000 || ${MyShip.UsedCargoCapacity} > ${Config.Miner.CargoThreshold}

--- a/Branches/Stable/Behaviors/obj_Hauler.iss
+++ b/Branches/Stable/Behaviors/obj_Hauler.iss
@@ -465,6 +465,17 @@ objectdef obj_Hauler
 			}
 			FleetMembers:Dequeue
 		}
+		
+		if !${FleetMembers.Peek(exists)}
+		{
+			call Safespots.WarpTo
+			wait 20
+			do
+			{
+				wait 5
+			}
+			while ${Me.ToEntity.Mode} != 2
+		}
 	}
 	
 /*


### PR DESCRIPTION
after dequeue of final miner/jetcan, it is necessary to delay the next BuildFleetMemberList for cases of long warp times to prevent warp attempt spam while in range of jetcan.

added an orehold check in HaulerFull