### PR TITLE
remove check for InStation

### DIFF
--- a/Branches/Stable/Behaviors/obj_Hauler.iss
+++ b/Branches/Stable/Behaviors/obj_Hauler.iss
@@ -459,7 +459,8 @@ objectdef obj_Hauler
 		}
 		else
 		{
-			if ${FleetMembers.Peek(exists)} && ${Local[${FleetMembers.Peek.Name}](exists)} && !${Character["CharID = ${FleetMembers.Peek.CharID}"].InStation}
+			; TODO: find a way to check if FleetMembers.Peek is in station or not
+			if ${FleetMembers.Peek(exists)} && ${Local[${FleetMembers.Peek.Name}](exists)}
 			{
 				call This.WarpToFleetMemberAndLoot ${FleetMembers.Peek.CharID}
 			}


### PR DESCRIPTION
the InStation member for top-level datatype Character will only check for the in-station status of the caller, not for queried pilots