### PR TITLE
move check for 1000 remaining cargo space

### DIFF
--- a/Branches/Stable/Behaviors/obj_Hauler.iss
+++ b/Branches/Stable/Behaviors/obj_Hauler.iss
@@ -1020,11 +1020,6 @@ objectdef obj_Hauler
 						wait 20
 					}
 				}
-				if ${Ship.CargoFreeSpace} < 1000
-				{
-					UI:UpdateConsole["DEBUG: obj_Hauler.LootEntity: Ship Cargo Free Space: ${Ship.CargoFreeSpace} < ${Ship.CargoMinimumFreeSpace}"]
-					break
-				}
 			}
 			while ${Cargo:Next(exists)}
 		}


### PR DESCRIPTION
this check was preventing the hauler from looting everything from the jetcans in cases where the miner wasn't mining ice. also, this check belonged in HaulerFull anyway.